### PR TITLE
Hotfix: Overide getExtras Method with placeholder

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/toolbarandroid/ReactToolbar.java
+++ b/android/src/main/java/com/reactnativecommunity/toolbarandroid/ReactToolbar.java
@@ -8,6 +8,7 @@
 package com.reactnativecommunity.toolbarandroid;
 
 import java.util.Map;
+import java.util.HashMap;
 import android.content.Context;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
@@ -114,6 +115,8 @@ public class ReactToolbar extends Toolbar {
       mWidth = width;
       mHeight = height;
     }
+
+    public Map<String,Object> getExtras() { return new HashMap<String,Object>(); }
 
     @Override
     public int getWidth() {


### PR DESCRIPTION
This is a fix that was discussed in https://github.com/react-native-toolbar-android/toolbar-android/issues/57 and was originally presented by @the-smart-home-maker 


I just whipped it into a pr. This is currently breaking for me as well and i don't want to resort to editing code after `yarn install` 

Not quite sure how these changes get merged upstream as it seems that `react-native` needs to update the dependency for this fix to propagate. 

Happy to change anything here. 

