### PR TITLE
Removing JCenter 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
Replacing jcenter to mavenCentral because jcenter is deprecated and is gonna be shutdown.